### PR TITLE
Allow specifying LIB_SUFFIX to install into /usr/lib64 if needed

### DIFF
--- a/src/libengrid/CMakeLists.txt
+++ b/src/libengrid/CMakeLists.txt
@@ -402,6 +402,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 target_link_libraries(libengrid ${VTK_LIBRARIES})
-INSTALL(TARGETS libengrid LIBRARY DESTINATION lib)
+INSTALL(TARGETS libengrid LIBRARY DESTINATION lib${LIB_SUFFIX})
 INSTALL(FILES ${libengrid_HEADERS} DESTINATION include/engrid)
 


### PR DESCRIPTION
Fedora and derived distributions install into /usr/lib64 for 64-bit libraries.  We set LIB_SUFFIX=64 on these arches.  This patch accepts that setting.